### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Chrome插件没有严格的项目结构要求，只要保证本目录有一个`m
 
 ```javascript
 {
-	// 清单文件的版本，这个必须写，而且必须是2
-	"manifest_version": 2,
+	// 清单文件的版本，这个必须写，在2023年，chrome浏览器将移除对2的支持，该使用3
+	"manifest_version": 3,
 	// 插件的名称
 	"name": "demo",
 	// 插件的版本


### PR DESCRIPTION
在2023年，谷歌的chrome浏览器会移除对清单列表为2的插件
⚠️ 再次说明！文章翻译的的 Manifest 版本为 V3，因为 MV2 再过一年将全面淘汰，具体描述请看下图（摘自官方文档）
![image](https://user-images.githubusercontent.com/114346243/216817829-03414b24-ac60-450c-97cd-85d98c8830c6.png)
